### PR TITLE
manifestに書き込まれるsprite画像のパスの修正

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -33,6 +33,7 @@ var TFCSpriteConverter = function (target, directory, prefix) {
   console.log(jsons);
   this.data = data;
   this.jsons = jsons;
+  this.target = target;
   this.directory = directory;
   this.prefix = prefix;
   this.sprites = sprites;
@@ -42,7 +43,7 @@ TFCSpriteConverter.prototype.convert = function() {
   var data = this.data;
   var jsons = this.jsons;
   var sprites = this.sprites;
-  var dir = this.directory;
+  var dir = path.relative(path.dirname(this.target), this.directory);
   var prefix = this.prefix;
 
   var imageData = {};//sprite画像名をキーとして、spriteJsonの"frames"の中身を保持します
@@ -116,7 +117,7 @@ TFCSpriteConverter.prototype.convert = function() {
     libProperties = libProperties.replace(/manifest: \[/g, function (manifestHeader) {
       manifestHeader += '\n';
       for (var prop in imageData) {
-        var str = '{src:"' + ('./' + dir + '/' + prop) + '", id:"' + prop.split('.')[0] + '"}';
+        var str = '{src:"' + (dir + '/' + prop) + '", id:"' + prop.split('.')[0] + '"}';
         if ((new RegExp(str, "g")).test(libProperties) === false) {
           manifestHeader += str + ',\n';
         }


### PR DESCRIPTION
下記のように、`tfcsprite`を深い階層のファイルをターゲットとして実行した際、
```bash
$ tree -L 2
.
└── public
    ├── images
    ├── sprites
    ├── sample.js
    ├── sample.html
    └── sample.fla
$ tfcsprite public/sample.js -s sprites
```

実行後、上記例でいう`sample.js`内のmanifestは以下のように書き込まれます。

```javascript
// library properties:
lib.properties = {
	width: 640,
	height: 920,
	fps: 12,
	color: "#666666",
	manifest: [
{src:"./public/sprites/sprites.png", id:"sprites"},
{src:"images/a.png", id:"a"}
	]
};
```

実際は、`{src:"sprites/sprites.png", id:"sprites"}`となるのが望ましいため、
targetとなるjsファイルと、指定されたspritesフォルダの中身の相対関係で、パスを書き込むようにしました。

```javascript
// library properties:
lib.properties = {
	width: 640,
	height: 920,
	fps: 12,
	color: "#666666",
	manifest: [
{src:"sprites/sprites.png", id:"sprites"},
{src:"images/a.png", id:"a"}
	]
};
```
