### PR TITLE
refactor(converter): スプライト画像がハイフンケースなどである場合も対応

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -146,7 +146,7 @@ TFCSpriteConverter.prototype.convert = function() {
       if(!imgData) {
         throw new Error(key + 'is not exist in json data');
       }
-      var lineResult = line.replace(key, imgData.spriteName) + '\n' + 'this.sourceRect = {x:' + imgData.x + ', y:' + imgData.y + ', width:' + imgData.w + ', height:' + imgData.h + '};\n';
+      var lineResult = line.replace('.' + key, '["' + imgData.spriteName + '"]') + '\n' + 'this.sourceRect = {x:' + imgData.x + ', y:' + imgData.y + ', width:' + imgData.w + ', height:' + imgData.h + '};\n';
       return lineResult;
   });
 

--- a/test/expected/sample.js
+++ b/test/expected/sample.js
@@ -21,7 +21,7 @@ lib.properties = {
 
 
 (lib._a = function() {
-	this.initialize(img.sample);
+	this.initialize(img["sample"]);
 this.sourceRect = {x:0, y:501, width:256, height:256};
 
 }).prototype = p = new cjs.Bitmap();
@@ -29,7 +29,7 @@ p.nominalBounds = new cjs.Rectangle(0,0,256,256);
 
 
 (lib._b = function() {
-	this.initialize(img.sample);
+	this.initialize(img["sample"]);
 this.sourceRect = {x:257, y:501, width:256, height:256};
 
 }).prototype = p = new cjs.Bitmap();
@@ -37,7 +37,7 @@ p.nominalBounds = new cjs.Rectangle(0,0,256,256);
 
 
 (lib._c = function() {
-	this.initialize(img.sample);
+	this.initialize(img["sample"]);
 this.sourceRect = {x:0, y:0, width:500, height:500};
 
 }).prototype = p = new cjs.Bitmap();


### PR DESCRIPTION
## Ex. sample-sprite.pngを反映させる場合
### convert前

```
this.initialize(img._a);
```
### convert後

```
this.initialize(img["sample-sprite"]);
```

これまでは、`this.initialize(img.sample-sprite);`となりシンタックスエラーが出てしまったので上記のように対応しました。
